### PR TITLE
(QA-3415) - Return session_timestamp

### DIFF
--- a/lib/beaker-benchmark/helpers.rb
+++ b/lib/beaker-benchmark/helpers.rb
@@ -75,6 +75,7 @@ module Beaker
 
           on(infrastructure_host, atop_cmd)
           @beaker_benchmark_start = Time.now
+          return @@session_timestamp
         end
 
         def stop_monitoring(infrastructure_host, process_regex='.*')


### PR DESCRIPTION
So that we can use this in perf test/helpers to copy over the right logs.