### PR TITLE
(SLV-568) Re-enable 'disk_read' measurement

### DIFF
--- a/lib/beaker-benchmark/helpers.rb
+++ b/lib/beaker-benchmark/helpers.rb
@@ -2,7 +2,6 @@ require 'csv'
 require 'fileutils'
 require 'time'
 
-# UPDATED BY SLV
 module Beaker
   module DSL
     module BeakerBenchmark

--- a/lib/beaker-benchmark/helpers.rb
+++ b/lib/beaker-benchmark/helpers.rb
@@ -2,6 +2,7 @@ require 'csv'
 require 'fileutils'
 require 'time'
 
+# UPDATED BY SLV
 module Beaker
   module DSL
     module BeakerBenchmark
@@ -33,7 +34,7 @@ module Beaker
 
         TMP_DIR = "tmp/atop/#{@@session_timestamp}"
 
-                # Example usage:
+        # Example usage:
         # test_name('measure_perf_on_puppetserver_start') {
         #   on(master, 'puppet resource service pe-puppetserver ensure=stopped')
         #   result = measure_perf_on(master, 'start_pe-puppetserver', true) {
@@ -135,13 +136,13 @@ module Beaker
               when 'PRM'
                 add_process_measure(:mem_usage, row[PROC_PID_INDEX], row[PROC_MEM_INDEX].to_i)
               when 'PRD'
-                # TODO: investigate why atop always shows disk_read as 0
-                # add_process_measure(:disk_read, row[PROC_PID_INDEX], row[PROC_DISK_READ_INDEX].to_i)
+                add_process_measure(:disk_read, row[PROC_PID_INDEX], row[PROC_DISK_READ_INDEX].to_i)
                 add_process_measure(:disk_write, row[PROC_PID_INDEX], row[PROC_DISK_WRITE_INDEX].to_i)
             end
           end
 
-          PerformanceResult.new({ :cpu => cpu_usage, :mem => mem_usage, :disk_read => disk_read, :disk_write => disk_write, :action => @action_name, :duration => duration, :processes => @processes_to_monitor, :logger => @logger, :hostname => infrastructure_host})
+          # rounding duration to improve results formatting
+          PerformanceResult.new({ :cpu => cpu_usage, :mem => mem_usage, :disk_read => disk_read, :disk_write => disk_write, :action => @action_name, :duration => duration.round(2), :processes => @processes_to_monitor, :logger => @logger, :hostname => infrastructure_host})
         end
 
         def set_processes_to_monitor(infrastructure_host, process_regex)
@@ -174,7 +175,7 @@ module Beaker
           def initialize(args)
             @avg_cpu = args[:cpu].empty? ? 0 : args[:cpu].inject{ |sum, el| sum + el } / args[:cpu].size
             @avg_mem = args[:mem].empty? ? 0 : args[:mem].inject{ |sum, el| sum + el } / args[:mem].size
-            # @avg_disk_read = args[:disk_read].empty? ? 0 : args[:disk_read].inject{ |sum, el| sum + el } / args[:disk_read].size
+            @avg_disk_read = args[:disk_read].empty? ? 0 : args[:disk_read].inject{ |sum, el| sum + el } / args[:disk_read].size
             @avg_disk_write = args[:disk_write].empty? ? 0 : args[:disk_write].inject{ |sum, el| sum + el } / args[:disk_write].size
             @action_name = args[:action]
             @duration = args[:duration]
@@ -186,7 +187,7 @@ module Beaker
             @processes.keys.each do |key|
               @processes[key][:avg_cpu] = @processes[key][:cpu_usage].inject{ |sum, el| sum + el } / @processes[key][:cpu_usage].size unless @processes[key][:cpu_usage].empty?
               @processes[key][:avg_mem] = @processes[key][:mem_usage].inject{ |sum, el| sum + el } / @processes[key][:mem_usage].size unless @processes[key][:mem_usage].empty?
-              # @processes[key][:avg_disk_read] = @processes[key][:disk_read].inject{ |sum, el| sum + el } / @processes[key][:disk_read].size unless @processes[key][:disk_read].empty?
+              @processes[key][:avg_disk_read] = @processes[key][:disk_read].inject{ |sum, el| sum + el } / @processes[key][:disk_read].size unless @processes[key][:disk_read].empty?
               @processes[key][:avg_disk_write] = @processes[key][:disk_write].inject{ |sum, el| sum + el } / @processes[key][:disk_write].size unless @processes[key][:disk_write].empty?
             end if @processes
             # TODO: At this point, we need to push these results into bigquery or elasticsearch

--- a/spec/beaker-benchmark/performance_result_spec.rb
+++ b/spec/beaker-benchmark/performance_result_spec.rb
@@ -12,9 +12,9 @@ end
 
 describe ClassMixedWithDSLHelpers do
   subject { Beaker::DSL::BeakerBenchmark::Helpers::PerformanceResult.new (
-            {:cpu => [60, 40], :mem => [6000, 4000], :disk_write => [600, 400], :action => 'test_action', :duration => 10,
-             :processes => {1000 => {:cmd => 'proc1', :cpu_usage => [10, 20], :mem_usage => [1000, 2000], :disk_write => [100, 200]},
-                            2000 => {:cmd => 'proc2', :cpu_usage => [20, 40], :mem_usage => [2000, 4000], :disk_write => [200, 400]}},
+            {:cpu => [60, 40], :mem => [6000, 4000], :disk_read => [600, 400], :disk_write => [600, 400], :action => 'test_action', :duration => 10,
+             :processes => {1000 => {:cmd => 'proc1', :cpu_usage => [10, 20], :mem_usage => [1000, 2000], :disk_read => [100, 200], :disk_write => [100, 200]},
+                            2000 => {:cmd => 'proc2', :cpu_usage => [20, 40], :mem_usage => [2000, 4000], :disk_read => [200, 400], :disk_write => [200, 400]}},
              :logger => logger, :hostname => 'my_host'}) }
 
   describe 'initialize' do
@@ -57,11 +57,11 @@ describe ClassMixedWithDSLHelpers do
       csv_file_content = file.read
       expected_content = <<-EOS
 Action,Duration,Avg CPU,Avg MEM,Avg DSK read,Avg DSK Write
-test_action,10,50,5000,,500
+test_action,10,50,5000,500,500
 
 Process pid,command,Avg CPU,Avg MEM,Avg DSK read,Avg DSK Write
-1000,'proc1',15,1500,,150
-2000,'proc2',30,3000,,300
+1000,'proc1',15,1500,150,150
+2000,'proc2',30,3000,300,300
       EOS
       expect(csv_file_content).to eq(expected_content)
     end


### PR DESCRIPTION
The 'disk_read' measurement was commented out with a note to investigate why the value was always 0. I tried uncommenting it and found that non-zero values are actually captured, so it seems that we should re-enable this measurement. I've updated the spec tests accordingly.