### PR TITLE
(SLV-562) Add the Bundler gem tasks to the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
 namespace :test do
 
@@ -151,4 +151,9 @@ namespace :docs do
       puts "Could not find a running YARD Server"
     end
   end
+end
+
+namespace :gem do
+  # add the Bundler gem tasks (build, clean, clobber, install, release)
+  require "bundler/gem_tasks"
 end


### PR DESCRIPTION
Added the Bundler gem tasks to the rakefile in the `:gem` namespace.

See: https://www.schneems.com/blogs/2016-03-18-bundler-release-tasks

gem_of adds the tasks in the `:gem` namespace which seems like a good idea for organization:
https://github.com/puppetlabs/gem_of/blob/42232d73188e8898799fe9f24798eccc942b2523/lib/gem_of/rake_tasks.rb#L35

